### PR TITLE
shellcheck: De-duplicate attachment of OCI artifacts

### DIFF
--- a/.tekton/konflux-test-multicluster-global-hub-pull-request.yaml
+++ b/.tekton/konflux-test-multicluster-global-hub-pull-request.yaml
@@ -408,10 +408,8 @@ spec:
           
               echo "Selecting auth"
               select-oci-auth $IMAGE_URL > $HOME/auth.json
-              echo "Attaching to ${IMAGE_URL} via the OCI 1.1 Referrers API"
-              oras attach --no-tty --registry-config "$HOME/auth.json" --distribution-spec v1.1-referrers-api --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
-              echo "Attaching to ${IMAGE_URL} via the OCI 1.1 Referrers Tag"
-              oras attach --no-tty --registry-config "$HOME/auth.json" --distribution-spec v1.1-referrers-tag --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+              echo "Attaching to ${IMAGE_URL}"
+              oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         workspaces:
           - name: workspace
     - name: sast-snyk-check


### PR DESCRIPTION
In PSSECAUT-605, a user reports that there is some funny behavior that is likely due to us invoking oras attach *twice* here.

There's no good reason to do it twice. Let's instead invoke it once, without specifying the distribution spec, and let oras choose for us.

Related: https://issues.redhat.com/browse/PSSECAUT-605

<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

## Related issue(s)

Fixes #